### PR TITLE
reduce code duplication by moving out common constants

### DIFF
--- a/.gget/remotes/tegonal-scripts/pulled
+++ b/.gget/remotes/tegonal-scripts/pulled
@@ -1,5 +1,5 @@
-v0.4.0	src/utility/replace-snippet.sh	ff68e521d4ff2dec34b4d2d5b314643814441993598c5769c979e904616cc554cd5c5ee752fd5e56cb7364ef37f5d443133e1ccbae52385aad609eca064c2df3	../lib/tegonal-scripts/src/utility/replace-snippet.sh
 v0.4.0	src/utility/parse-fn-args.sh	ca3d27135035c6b28819fec2536051358cb8f1067d225afca29cf6d6623dc6f5a742e9e40b3f167f707043bb2e624e51b3c93c8c5ca2608896a9b2159aebf669	../lib/tegonal-scripts/src/utility/parse-fn-args.sh
 v0.4.0	src/utility/update-bash-docu.sh	b4cbbf7b478e2c83003830601a9996375017eee6a5b7f6d0ba805eade4f30320933b469feba3a1da78f25128b28d657a944cb68cced051a4d95e430399d96049	../lib/tegonal-scripts/src/utility/update-bash-docu.sh
 v0.4.0	src/utility/parse-args.sh	7976106cb8c3c4128ab57a8ab24198e20a6373965d6cd857340b7167776408e43799f11cf9a0296febcb7197c7557ad6bd3c95f6ec943030f70bed690c02a320	../lib/tegonal-scripts/src/utility/parse-args.sh
+v0.4.0	src/utility/replace-snippet.sh	ff68e521d4ff2dec34b4d2d5b314643814441993598c5769c979e904616cc554cd5c5ee752fd5e56cb7364ef37f5d443133e1ccbae52385aad609eca064c2df3	../lib/tegonal-scripts/src/utility/replace-snippet.sh
 v0.4.0	src/utility/replace-help-snippet.sh	0b8428cd98f5e04707892accf51fecbe877362fb3b4e9454246a7c127db60f89be10d179871048f77dc85c050d977b76c9f2e371dd483ef0643c780ab51609a9	../lib/tegonal-scripts/src/utility/replace-help-snippet.sh

--- a/scripts/update-docu.sh
+++ b/scripts/update-docu.sh
@@ -16,7 +16,8 @@ source "$projectDir/lib/tegonal-scripts/src/utility/replace-help-snippet.sh"
 
 find "$projectDir/src" -maxdepth 1 -name "*.sh" \
 	-not -name "*.doc.sh" \
-	-not -name "gpg-utils.sh" \
+	-not -name "*utils.sh" \
+	-not -name "*.source.sh" \
 	-print0 |
 	while read -r -d $'\0' script; do
 		declare relative

--- a/src/directories.source.sh
+++ b/src/directories.source.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC2168,SC2154
+
+local -r remotesDirectory="$workingDirectory/remotes"
+local -r remoteDirectory="$remotesDirectory/$remote"
+local -r publicKeys="$remoteDirectory/public-keys"
+local -r repo="$remoteDirectory/repo"
+local -r gpgDir="$publicKeys/gpg"

--- a/src/gget-pull.sh
+++ b/src/gget-pull.sh
@@ -25,255 +25,260 @@
 #
 ###################################
 
-set -e
+set -eu
 
-declare remote tag path pullDirectory unsecure forceNoVerification workingDirectory
-# shellcheck disable=SC2034
-declare params=(
-	remote '-r|--remote' 'name of the remote repository'
-	tag '-t|--tag' 'git tag used to pull the file/directory'
-	path '-p|--path' 'path in remote repository which shall be pulled (file or directory)'
-	pullDirectory '-d|--directory' '(optional) directory into which files are pulled -- default: pull directory of this remote (defined during "remote add" and stored in .gget/<remote>/pull.args)'
-	workingDirectory '-w|--working-directory' '(optional) path which gget shall use as working directory -- default: .gget'
-	unsecure '--unsecure' '(optional) if set to true, the remote does not need to have GPG key(s) defined at .gget/<remote>/*.asc -- default: false'
-	forceNoVerification '--unsecure-no-verification' '(optional) if set to true, implies --unsecure true and does not verify even if gpg keys were found at .gget/<remote>/*.asc -- default: false'
-)
+function gget-pull() {
+	local scriptDir
+	scriptDir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
+	local -r scriptDir
+	local currentDir
+	currentDir=$(pwd)
+	local -r currentDir
 
-declare examples
-examples=$(
-	cat <<-EOM
-		# pull the file src/utility/update-bash-docu.sh from remote tegonal-scripts
-		# in version v0.1.0 (i.e. tag v0.1.0 is used)
-		gget pull -r tegonal-scripts -t v0.1.0 -p src/utility/update-bash-docu.sh
+	source "$scriptDir/shared-patterns.source.sh"
+	source "$scriptDir/gpg-utils.sh"
 
-		# pull the directory src/utility/ from remote tegonal-scripts
-		# in version v0.1.0 (i.e. tag v0.1.0 is used)
-		gget pull -r tegonal-scripts -t v0.1.0 -p src/utility/
-	EOM
-)
+	local -r UNSECURE_NO_VERIFY_PATTERN='--unsecure-no-verification'
 
-scriptDir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
-source "$scriptDir/gpg-utils.sh"
-source "$scriptDir/../lib/tegonal-scripts/src/utility/parse-args.sh" || exit 200
+	local remote tag path pullDirectory unsecure forceNoVerification workingDirectory
+	# shellcheck disable=SC2034
+	local -r params=(
+		remote "$REMOTE_PATTERN" 'name of the remote repository'
+		tag '-t|--tag' 'git tag used to pull the file/directory'
+		path '-p|--path' 'path in remote repository which shall be pulled (file or directory)'
+		pullDirectory "$PULL_DIR_PATTERN" '(optional) directory into which files are pulled -- default: pull directory of this remote (defined during "remote add" and stored in .gget/<remote>/pull.args)'
+		workingDirectory "$WORKING_DIR_PATTERN" '(optional) path which gget shall use as working directory -- default: .gget'
+		unsecure "$UNSECURE_PATTERN" '(optional) if set to true, the remote does not need to have GPG key(s) defined at .gget/<remote>/*.asc -- default: false'
+		forceNoVerification "$UNSECURE_NO_VERIFY_PATTERN" "(optional) if set to true, implies $UNSECURE_PATTERN true and does not verify even if gpg keys were found at .gget/<remote>/*.asc -- default: false"
+	)
 
-declare currentDir
-currentDir=$(pwd)
+	local -r examples=$(
+		cat <<-EOM
+			# pull the file src/utility/update-bash-docu.sh from remote tegonal-scripts
+			# in version v0.1.0 (i.e. tag v0.1.0 is used)
+			gget pull -r tegonal-scripts -t v0.1.0 -p src/utility/update-bash-docu.sh
 
-# parsing once so that we get workingDirectory and remote
-# redirecting output to /dev/null because we don't want to see 'ignored argument warnings' twice
-# || true because --help returns 99 and we don't want to exit at this point (because we redirect output)
-parseArguments params "$examples" "$@" >/dev/null || true
-if ! [ -v workingDirectory ]; then workingDirectory="./.gget"; fi
+			# pull the directory src/utility/ from remote tegonal-scripts
+			# in version v0.1.0 (i.e. tag v0.1.0 is used)
+			gget pull -r tegonal-scripts -t v0.1.0 -p src/utility/
+		EOM
+	)
+	source "$scriptDir/../lib/tegonal-scripts/src/utility/parse-args.sh" || exit 200
 
-declare args=()
-if [ -n "$remote" ]; then
-	declare pullArgsFile="$workingDirectory/$remote/pull.args"
-	if [ -f "$pullArgsFile" ]; then
-		defaultArguments=$(cat "$pullArgsFile")
-		eval 'for arg in '"$defaultArguments"'; do
-			args+=("$arg");
-	done'
+	# parsing once so that we get workingDirectory and remote
+	# redirecting output to /dev/null because we don't want to see 'ignored argument warnings' twice
+	# || true because --help returns 99 and we don't want to exit at this point (because we redirect output)
+	parseArguments params "$examples" "$@" >/dev/null || true
+	if ! [ -v workingDirectory ]; then workingDirectory="./.gget"; fi
+
+	local -a args=()
+	if [ -v remote ] && [ -n "$remote" ]; then
+		local -r pullArgsFile="$workingDirectory/remotes/$remote/pull.args"
+		if [ -f "$pullArgsFile" ]; then
+			defaultArguments=$(cat "$pullArgsFile")
+			eval 'for arg in '"$defaultArguments"'; do
+					args+=("$arg");
+			done'
+		fi
 	fi
-fi
-args+=("$@")
-parseArguments params "$examples" "${args[@]}"
+	args+=("$@")
+	parseArguments params "$examples" "${args[@]}"
 
-if ! [ -v forceNoVerification ]; then forceNoVerification=false; fi
-if ! [ -v unsecure ]; then unsecure="$forceNoVerification"; fi
-checkAllArgumentsSet params "$examples"
+	if ! [ -v forceNoVerification ]; then forceNoVerification=false; fi
+	if ! [ -v unsecure ]; then unsecure="$forceNoVerification"; fi
+	checkAllArgumentsSet params "$examples"
 
-if ! [ -d "$workingDirectory" ]; then
-	printf >&2 "\033[1;31mERROR\033[0m: working directory \033[0;36m%s\033[0m does not exist\n" "$workingDirectory"
-	echo >&2 "Check for typos and/or use $WORKING_DIR_PATTERN to specify another"
-	exit 9
-fi
+	if ! [ -d "$workingDirectory" ]; then
+		printf >&2 "\033[1;31mERROR\033[0m: working directory \033[0;36m%s\033[0m does not exist\n" "$workingDirectory"
+		echo >&2 "Check for typos and/or use $WORKING_DIR_PATTERN to specify another"
+		exit 9
+	fi
 
-# make directory paths absolute
-workingDirectory=$(readlink -m "$workingDirectory")
-declare pullDirectoryAbsolute
-pullDirectoryAbsolute=$(readlink -m "$pullDirectory")
+	# make directory paths absolute
+	local -r workingDirectory=$(readlink -m "$workingDirectory")
+	local -r pullDirectoryAbsolute=$(readlink -m "$pullDirectory")
 
-declare remoteDirectory="$workingDirectory/remotes/$remote"
-declare repo="$remoteDirectory/repo"
-declare publicKeys="$remoteDirectory/public-keys"
-declare gpgDir="$publicKeys/gpg"
+	declare remoteDirectory publicKeys repo gpgDir
+	source "$scriptDir/directories.source.sh"
 
-declare doVerification
-if [ "$forceNoVerification" == true ]; then
-	doVerification=false
-else
-	doVerification=true
-	if ! [ -d "$gpgDir" ]; then
-		printf "\033[0;36mINFO\033[0m: no gpg dir in %s\nWe are going to import all public keys which are stored in %s\n" "$gpgDir" "$publicKeys"
-		function findAsc() {
-			find "$publicKeys" -maxdepth 1 -type f -name "*.asc" "$@"
-		}
-		if (($(findAsc | wc -l) == 0)); then
-			if [ "$unsecure" == true ]; then
-				printf "\033[1;33mWARNING\033[0m: no GPG key found, won't be able to verify files (which is OK because --unsecure true was specified)\n"
-				doVerification=false
+	local doVerification
+	if [ "$forceNoVerification" == true ]; then
+		doVerification=false
+	else
+		doVerification=true
+		if ! [ -d "$gpgDir" ]; then
+			printf "\033[0;36mINFO\033[0m: no gpg dir in %s\nWe are going to import all public keys which are stored in %s\n" "$gpgDir" "$publicKeys"
+			function findAsc() {
+				find "$publicKeys" -maxdepth 1 -type f -name "*.asc" "$@"
+			}
+			if (($(findAsc | wc -l) == 0)); then
+				if [ "$unsecure" == true ]; then
+					printf "\033[1;33mWARNING\033[0m: no GPG key found, won't be able to verify files (which is OK because %s true was specified)\n" "$UNSECURE_PATTERN"
+					doVerification=false
+				else
+					printf >&2 "\033[1;31mERROR\033[0m: no public keys for remote \033[0;36m%s\033[0m defined in %s\n" "$remote" "$publicKeys"
+					exit 1
+				fi
 			else
-				printf >&2 "\033[1;31mERROR\033[0m: no public keys for remote \033[0;36m%s\033[0m defined in %s\n" "$remote" "$publicKeys"
+				mkdir "$gpgDir"
+				chmod 700 "$gpgDir"
+				findAsc -print0 |
+					while read -r -d $'\0' file; do
+						importKey "$gpgDir" "$file" --confirm=false
+					done
+			fi
+		fi
+		if [ "$unsecure" == true ] && [ "$doVerification" == true ]; then
+			printf "\033[0;36mINFO\033[0m: gpg key found going to perform verification even though %s true was specified\n" "$UNSECURE_PATTERN"
+		fi
+	fi
+
+	if ! [ -d "$pullDirectoryAbsolute" ]; then
+		mkdir -p "$pullDirectoryAbsolute" || (printf >&2 "\033[1;31mERROR\033[0m: failed to create the pull directory %s\n" "$pullDirectoryAbsolute" && exit 1)
+	fi
+
+	if [ -f "$repo" ]; then
+		printf >&2 "\033[1;31mERROR\033[0m: looks like the remote \033[0;36m%s\033[0m is broken there is a file at the repo's location: %s\n" "$remote" "$remoteDirectory"
+		exit 1
+	elif ! [ -d "$repo" ]; then
+		printf "\033[0;36mINFO\033[0m: repo directory does not exist for remote \033[0;36m%s\033[0m. We are going to re-initialise it based on the stored gitconfig\n" "$remote"
+		mkdir -p "$repo"
+		cd "$repo"
+		git init
+		cp "$remoteDirectory/gitconfig" "$repo/.git/config"
+	fi
+
+	cd "$repo"
+	git ls-remote -t "$remote" | grep "$tag" >/dev/null || (printf >&2 "\033[1;31mERROR\033[0m: remote \033[0;36m%s\033[0m does not have arg tag \033[0;36m%s\033[0m\nFollowing the available tags:\n" "$remote" "$tag" && git ls-remote -t "$remote" && exit 1)
+
+	# show commands as output
+	set -x
+
+	git fetch --depth 1 "$remote" "refs/tags/$tag:refs/tags/$tag"
+	git checkout "tags/$tag" -- "$path"
+
+	# don't show commands in output anymore
+	{ set +x; } 2>/dev/null
+
+	function mentionUnsecure() {
+		if ! [ "$unsecure" == true ]; then
+			printf "Disable this check via %s true\n" "$UNSECURE_PATTERN"
+		else
+			printf "Disable this check via %s true\n" "$UNSECURE_NO_VERIFY_PATTERN"
+		fi
+	}
+
+	local -r SIG_EXTENSION="sig"
+
+	function getSignatureOfSingleFetchedFile() {
+		if [ "$doVerification" == true ] && [ -f "$repo/$path" ]; then
+			set -x
+			# is arg file, fetch also the corresponding signature
+			if ! git checkout "tags/$tag" -- "$path.$SIG_EXTENSION"; then
+				# don't show commands in output anymore
+				{ set +x; } 2>/dev/null
+
+				printf >&2 "\033[1;31mERROR\033[0m: no signature file found, aborting. "
+				mentionUnsecure >&2
 				exit 1
 			fi
-		else
-			mkdir "$gpgDir"
-			chmod 700 "$gpgDir"
-			findAsc -print0 |
-				while read -r -d $'\0' file; do
-					importKey "$gpgDir" "$file" --confirm=false
-				done
-		fi
-	fi
-	if [ "$unsecure" == true ] && [ "$doVerification" == true ]; then
-		printf "\033[0;36mINFO\033[0m: gpg key found going to perform verification even though --unsecure true was specified\n"
-	fi
-fi
 
-if ! [ -d "$pullDirectoryAbsolute" ]; then
-	mkdir -p "$pullDirectoryAbsolute" || (printf >&2 "\033[1;31mERROR\033[0m: failed to create the pull directory %s\n" "$pullDirectoryAbsolute" && exit 1)
-fi
-
-if [ -f "$repo" ]; then
-	printf >&2 "\033[1;31mERROR\033[0m: looks like the remote \033[0;36m%s\033[0m is broken there is a file at the repo's location: %s\n" "$remote" "$remoteDirectory"
-	exit 1
-elif ! [ -d "$repo" ]; then
-	printf "\033[0;36mINFO\033[0m: repo directory does not exist for remote \033[0;36m%s\033[0m. We are going to re-initialise it based on the stored gitconfig\n" "$remote"
-	mkdir -p "$repo"
-	cd "$repo"
-	git init
-	cp "$remoteDirectory/gitconfig" "$repo/.git/config"
-fi
-
-cd "$repo"
-git ls-remote -t "$remote" | grep "$tag" >/dev/null || (printf >&2 "\033[1;31mERROR\033[0m: remote \033[0;36m%s\033[0m does not have arg tag \033[0;36m%s\033[0m\nFollowing the available tags:\n" "$remote" "$tag" && git ls-remote -t "$remote" && exit 1)
-
-# show commands as output
-set -x
-
-git fetch --depth 1 "$remote" "refs/tags/$tag:refs/tags/$tag"
-git checkout "tags/$tag" -- "$path"
-
-# don't show commands in output anymore
-{ set +x; } 2>/dev/null
-
-function mentionUnsecure() {
-	if ! [ "$unsecure" == true ]; then
-		printf "Disable this check via --unsecure true\n"
-	else
-		printf "Disable this check via --unsecure-no-verification true\n"
-	fi
-}
-
-declare sigExtension="sig"
-
-function getSignatureOfSingleFetchedFile() {
-	if [ "$doVerification" == true ] && [ -f "$repo/$path" ]; then
-		set -x
-		# is arg file, fetch also the corresponding signature
-		if ! git checkout "tags/$tag" -- "$path.$sigExtension"; then
 			# don't show commands in output anymore
 			{ set +x; } 2>/dev/null
-
-			printf >&2 "\033[1;31mERROR\033[0m: no signature file found, aborting. "
-			mentionUnsecure >&2
-			exit 1
 		fi
-
-		# don't show commands in output anymore
-		{ set +x; } 2>/dev/null
-	fi
-}
-getSignatureOfSingleFetchedFile
-
-function cleanupRepo() {
-	# cleanup the repo in case we exit unexpected
-	find "$repo" -maxdepth 1 -type d -not -path "$repo" -not -name ".git" -exec rm -r {} \;
-}
-
-trap cleanupRepo EXIT
-
-declare numberOfPulledFiles=0
-declare pulledFiles="$remoteDirectory/pulled"
-if ! [ -f "$pulledFiles" ]; then
-	touch "$pulledFiles" || (printf >&2 "\033[1;31mERROR\033[0m: failed to create pulled at %s\n" "$pulledFiles" && exit 1)
-fi
-
-function moveFile() {
-	local file=$1
-
-	declare relativeTarget
-	relativeTarget=$(realpath --relative-to="$workingDirectory" "$pullDirectoryAbsolute/$file")
-	declare absoluteTarget
-	absoluteTarget="$pullDirectoryAbsolute/$file"
-	mkdir -p "$(dirname "$absoluteTarget")"
-	declare sha
-	sha=$(sha512sum "$repo/$file" | cut -d " " -f 1)
-	declare entry="$tag	$file	$sha	$relativeTarget"
-	declare currentEntry
-	set +e
-	function grepByFile() {
-		grep -E "^[^\t]+	$file" "$@" "$pulledFiles"
 	}
-	currentEntry=$(grepByFile)
-	set -e
-	declare currentVersion
-	currentVersion=$(echo "$currentEntry" | perl -0777 -pe 's/([^\t]+)\t.*/$1/')
+	getSignatureOfSingleFetchedFile
 
-	if [ "$currentEntry" == "" ]; then
-		echo "$entry" >>"$pulledFiles"
-	elif ! [ "$currentVersion" == "$tag" ]; then
-		printf "\033[0;36mINFO\033[0m: the file was pulled before in version %s, going to override with version %s \033[0;36m%s\033[0m\n" "$currentVersion" "$tag" "$pullDirectory/$file"
-		# we could warn about a version which was older
-		grepByFile -v >"$pulledFiles.new"
-		mv "$pulledFiles.new" "$pulledFiles"
-		echo "$entry" >>"$pulledFiles"
-	else
-		declare currentSha
-		currentSha=$(echo "$currentEntry" | perl -0777 -pe 's/[^\t]+\t[^\t]+\t([0-9a-f]+)\t.*/$1/')
-		if ! [ "$currentSha" == "$sha" ]; then
-			printf "\033[1;33mWARNING\033[0m: looks like the sha512 of \033[0;36m%s\033[0m changed in tag %s\n" "$file" "$tag"
-			git --no-pager diff "$(echo "$currentSha" | git hash-object -w --stdin)" "$(echo "$sha" | git hash-object -w --stdin)" --word-diff=color --word-diff-regex . | grep -A 1 @@ | tail -n +2
-			printf "Won't pull the file, remove the entry from %s if you want to pull it nonetheless\n" "$pulledFiles"
-			rm "$repo/$file"
-			return
-		elif ! grep "$entry" "$pulledFiles" >/dev/null; then
-			declare currentLocation
-			currentLocation=$(echo "$currentEntry" | perl -0777 -pe 's/[^\t]+\t[^\t]+\t[^\t]+\t([^\t]+)/$1/')
-			printf "\033[1;33mWARNING\033[0m: the file was previously pulled to \033[0;36m%s\033[0m (new location would have been %s)\n" "$(realpath --relative-to="$currentDir" "$workingDirectory/$currentLocation")" "$pullDirectory/$file"
-			printf "Won't pull the file again, remove the entry from %s if you want to pull it nonetheless\n" "$pulledFiles"
-			rm "$repo/$file"
-			return
-		elif [ -f "$absoluteTarget" ]; then
-			printf "\033[0;36mINFO\033[0m: the file was pulled before to the same location, going to override \033[0;36m%s\033[0m\n" "$pullDirectory/$file"
-		fi
+	function cleanupRepo() {
+		local repo=$1
+		# cleanup the repo in case we exit unexpected
+		find "$repo" -maxdepth 1 -type d -not -path "$repo" -not -name ".git" -exec rm -r {} \;
+	}
+	# local variable repo is not available for trap thus we expand it here via eval
+	eval "trap 'cleanupRepo \"$repo\"' EXIT"
+
+	local -i numberOfPulledFiles=0
+	local -r pulledFiles="$remoteDirectory/pulled"
+	if ! [ -f "$pulledFiles" ]; then
+		touch "$pulledFiles" || (printf >&2 "\033[1;31mERROR\033[0m: failed to create pulled at %s\n" "$pulledFiles" && exit 1)
 	fi
-	mv "$repo/$file" "$absoluteTarget"
 
-	((numberOfPulledFiles += 1))
+	function moveFile() {
+		local file=$1
+
+		local relativeTarget
+		relativeTarget=$(realpath --relative-to="$workingDirectory" "$pullDirectoryAbsolute/$file")
+		local -r absoluteTarget="$pullDirectoryAbsolute/$file"
+		mkdir -p "$(dirname "$absoluteTarget")"
+		local sha
+		sha=$(sha512sum "$repo/$file" | cut -d " " -f 1)
+		local -r entry="$tag	$file	$sha	$relativeTarget"
+
+		function grepByFile() {
+			grep -E "^[^\t]+	$file" "$@" "$pulledFiles"
+		}
+		local -r currentEntry=$(grepByFile || true)
+		local currentVersion
+		currentVersion=$(echo "$currentEntry" | perl -0777 -pe 's/([^\t]+)\t.*/$1/')
+
+		if [ "$currentEntry" == "" ]; then
+			echo "$entry" >>"$pulledFiles"
+		elif ! [ "$currentVersion" == "$tag" ]; then
+			printf "\033[0;36mINFO\033[0m: the file was pulled before in version %s, going to override with version %s \033[0;36m%s\033[0m\n" "$currentVersion" "$tag" "$pullDirectory/$file"
+			# we could warn about a version which was older
+			grepByFile -v >"$pulledFiles.new"
+			mv "$pulledFiles.new" "$pulledFiles"
+			echo "$entry" >>"$pulledFiles"
+		else
+			local currentSha
+			currentSha=$(echo "$currentEntry" | perl -0777 -pe 's/[^\t]+\t[^\t]+\t([0-9a-f]+)\t.*/$1/')
+			if ! [ "$currentSha" == "$sha" ]; then
+				printf "\033[1;33mWARNING\033[0m: looks like the sha512 of \033[0;36m%s\033[0m changed in tag %s\n" "$file" "$tag"
+				git --no-pager diff "$(echo "$currentSha" | git hash-object -w --stdin)" "$(echo "$sha" | git hash-object -w --stdin)" --word-diff=color --word-diff-regex . | grep -A 1 @@ | tail -n +2
+				printf "Won't pull the file, remove the entry from %s if you want to pull it nonetheless\n" "$pulledFiles"
+				rm "$repo/$file"
+				return
+			elif ! grep "$entry" "$pulledFiles" >/dev/null; then
+				local currentLocation
+				currentLocation=$(echo "$currentEntry" | perl -0777 -pe 's/[^\t]+\t[^\t]+\t[^\t]+\t([^\t]+)/$1/')
+				printf "\033[1;33mWARNING\033[0m: the file was previously pulled to \033[0;36m%s\033[0m (new location would have been %s)\n" "$(realpath --relative-to="$currentDir" "$workingDirectory/$currentLocation")" "$pullDirectory/$file"
+				printf "Won't pull the file again, remove the entry from %s if you want to pull it nonetheless\n" "$pulledFiles"
+				rm "$repo/$file"
+				return
+			elif [ -f "$absoluteTarget" ]; then
+				printf "\033[0;36mINFO\033[0m: the file was pulled before to the same location, going to override \033[0;36m%s\033[0m\n" "$pullDirectory/$file"
+			fi
+		fi
+		mv "$repo/$file" "$absoluteTarget"
+
+		((numberOfPulledFiles += 1))
+	}
+
+	while read -r -d $'\0' file; do
+		if [ "$doVerification" == true ] && [ -f "$file.$SIG_EXTENSION" ]; then
+			printf "verifying \033[0;36m%s\033[0m\n" "$file"
+			if [ -d "$pullDirectoryAbsolute/$file" ]; then
+				printf >&2 "\033[1;31mERROR\033[0m: there exists a directory with the same name at %s\n" "$pullDirectoryAbsolute/$file"
+				exit 1
+			fi
+			gpg --homedir="$gpgDir" --verify "$file.$SIG_EXTENSION" "$file"
+			rm "$file.$SIG_EXTENSION"
+			moveFile "$file"
+		elif [ "$doVerification" == true ]; then
+			printf "\033[1;33mWARNING\033[0m: there was no corresponding *.%s file for %s, skipping it. " "$SIG_EXTENSION" "$file"
+			rm "$file"
+		else
+			moveFile "$file"
+		fi
+	done < <(find "$path" -type f -not -name "*.$SIG_EXTENSION" -print0)
+
+	if ((numberOfPulledFiles > 0)); then
+		printf "\033[1;32mSUCCESS\033[0m: %s files pulled from %s %s\n" "$numberOfPulledFiles" "$remote" "$path"
+	else
+		printf >&2 "\033[1;31mERROR\033[0m: 0 files could be pulled from %s, most likely verification failed, see above.\n" "$remote"
+		exit 1
+	fi
+
 }
 
-while read -r -d $'\0' file; do
-	if [ "$doVerification" == true ] && [ -f "$file.$sigExtension" ]; then
-		printf "verifying \033[0;36m%s\033[0m\n" "$file"
-		if [ -d "$pullDirectoryAbsolute/$file" ]; then
-			printf >&2 "\033[1;31mERROR\033[0m: there exists a directory with the same name at %s\n" "$pullDirectoryAbsolute/$file"
-			exit 1
-		fi
-		gpg --homedir="$gpgDir" --verify "$file.$sigExtension" "$file"
-		rm "$file.$sigExtension"
-		moveFile "$file"
-	elif [ "$doVerification" == true ]; then
-		printf "\033[1;33mWARNING\033[0m: there was no corresponding *.%s file for %s, skipping it. " "$sigExtension" "$file"
-		rm "$file"
-	else
-		moveFile "$file"
-	fi
-done < <(find "$path" -type f -not -name "*.$sigExtension" -print0)
-
-if ((numberOfPulledFiles > 0)); then
-	printf "\033[1;32mSUCCESS\033[0m: %s files pulled from %s %s\n" "$numberOfPulledFiles" "$remote" "$path"
-else
-	printf >&2 "\033[1;31mERROR\033[0m: 0 files could be pulled from %s, most likely verification failed, see above.\n" "$remote"
-	exit 1
-fi
+gget-pull "$@"

--- a/src/gget-remote.sh
+++ b/src/gget-remote.sh
@@ -26,258 +26,263 @@
 #
 ###################################
 
-set -e
+set -eu
 
-declare scriptDir
-scriptDir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
-source "$scriptDir/gpg-utils.sh"
-source "$scriptDir/../lib/tegonal-scripts/src/utility/parse-args.sh" || exit 200
+function gget-remote() {
 
-declare DEFAULT_WORKING_DIR='.gget'
-declare WORKING_DIR_PATTERN='-w|--working-directory'
+	local scriptDir
+	scriptDir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
+	local -r scriptDir
+	local currentDir
+	currentDir=$(pwd)
+	local -r currentDir
 
-function add() {
+	source "$scriptDir/shared-patterns.source.sh"
+	source "$scriptDir/gpg-utils.sh"
+	source "$scriptDir/../lib/tegonal-scripts/src/utility/parse-args.sh" || exit 200
 
-	declare remote url pullDirectory workingDirectory unsecure
-	# shellcheck disable=SC2034
-	declare params=(
-		remote '-r|--remote' 'name to refer to this the remote repository'
-		url '-u|--url' 'url of the remote repository'
-		pullDirectory '-d|--directory' '(optional) directory into which files are pulled -- default: lib/<remote>'
-		unsecure '--unsecure' '(optional) if set to true, the remote does not need to have GPG key(s) defined at .gget/*.asc -- default: false'
-		workingDirectory "$WORKING_DIR_PATTERN" '(optional) path which gget shall use as working directory -- default: .gget'
-	)
-	declare examples
-	examples=$(
-		cat <<-EOM
-			# adds the remote tegonal-scripts with url https://github.com/tegonal/scripts
-			# uses the default location lib/tegonal-scripts for the files which will be pulled from this remote
-			gget remote add -r tegonal-scripts -u https://github.com/tegonal/scripts
+	function add() {
 
-			# uses a custom pull directory, files of the remote tegonal-scripts will now
-			# be placed into scripts/lib/tegonal-scripts instead of default location lib/tegonal-scripts
-			gget remote add -r tegonal-scripts -u https://github.com/tegonal/scripts -d scripts/lib/tegonal-scripts
+		local remote url pullDirectory workingDirectory unsecure
+		# shellcheck disable=SC2034
+		local -ra params=(
+			remote "$REMOTE_PATTERN" 'name to refer to this the remote repository'
+			url '-u|--url' 'url of the remote repository'
+			pullDirectory "$PULL_DIR_PATTERN" '(optional) directory into which files are pulled -- default: lib/<remote>'
+			unsecure "$UNSECURE_PATTERN" "(optional) if set to true, the remote does not need to have GPG key(s) defined at $DEFAULT_WORKING_DIR/*.asc -- default: false"
+			workingDirectory "$WORKING_DIR_PATTERN" "(optional) path which gget shall use as working directory -- default: $DEFAULT_WORKING_DIR"
+		)
+		local -r examples=$(
+			cat <<-EOM
+				# adds the remote tegonal-scripts with url https://github.com/tegonal/scripts
+				# uses the default location lib/tegonal-scripts for the files which will be pulled from this remote
+				gget remote add -r tegonal-scripts -u https://github.com/tegonal/scripts
 
-			# Does not complain if the remote does not provide a GPG key for verification (but still tries to fetch one)
-			gget remote add -r tegonal-scripts -u https://github.com/tegonal/scripts --unsecure true
+				# uses a custom pull directory, files of the remote tegonal-scripts will now
+				# be placed into scripts/lib/tegonal-scripts instead of default location lib/tegonal-scripts
+				gget remote add -r tegonal-scripts -u https://github.com/tegonal/scripts -d scripts/lib/tegonal-scripts
 
-			# uses a custom working directory
-			gget remote add -r tegonal-scripts -u https://github.com/tegonal/scripts -w .github/.gget
-		EOM
-	)
-	parseArguments params "$examples" "$@"
-	if ! [ -v pullDirectory ]; then pullDirectory="lib/$remote"; fi
-	if ! [ -v unsecure ]; then unsecure=false; fi
-	if ! [ -v workingDirectory ]; then workingDirectory="$DEFAULT_WORKING_DIR"; fi
-	checkAllArgumentsSet params "$examples"
+				# Does not complain if the remote does not provide a GPG key for verification (but still tries to fetch one)
+				gget remote add -r tegonal-scripts -u https://github.com/tegonal/scripts --unsecure true
 
-	# make directory paths absolute
-	workingDirectory=$(readlink -m "$workingDirectory")
+				# uses a custom working directory
+				gget remote add -r tegonal-scripts -u https://github.com/tegonal/scripts -w .github/.gget
+			EOM
+		)
+		parseArguments params "$examples" "$@"
+		if ! [ -v pullDirectory ]; then pullDirectory="lib/$remote"; fi
+		if ! [ -v unsecure ]; then unsecure=false; fi
+		if ! [ -v workingDirectory ]; then workingDirectory="$DEFAULT_WORKING_DIR"; fi
+		checkAllArgumentsSet params "$examples"
 
-	mkdir -p "$workingDirectory/remotes"
+		# make directory paths absolute
+		local -r workingDirectory=$(readlink -m "$workingDirectory")
 
-	declare remoteDirectory="$workingDirectory/remotes/$remote"
+		mkdir -p "$workingDirectory/remotes"
 
-	if [ -f "$remoteDirectory" ]; then
-		printf >&2 "\033[1;31mERROR\033[0m: cannot create remote directory, there is a file at this location: %s\n" "$remoteDirectory"
-		exit 9
-	elif [ -d "$remoteDirectory" ]; then
-		printf >&2 "\033[1;31mERROR\033[0m: remote \033[0;36m%s\033[0m already exists, remove with: gget remote remove %s\n" "$remote" "$remote"
-		exit 9
-	fi
+		declare remoteDirectory publicKeys repo gpgDir
+		source "$scriptDir/directories.source.sh"
 
-	mkdir "$remoteDirectory" || (printf >&2 "\033[1;31mERROR\033[0m: failed to create remote directory %s\n" "$remoteDirectory" && exit 1)
-	echo "--directory \"$pullDirectory\"" >"$workingDirectory/$remote/pull.args"
+		if [ -f "$remoteDirectory" ]; then
+			printf >&2 "\033[1;31mERROR\033[0m: cannot create remote directory, there is a file at this location: %s\n" "$remoteDirectory"
+			exit 9
+		elif [ -d "$remoteDirectory" ]; then
+			printf >&2 "\033[1;31mERROR\033[0m: remote \033[0;36m%s\033[0m already exists, remove with: gget remote remove %s\n" "$remote" "$remote"
+			exit 9
+		fi
 
-	declare publicKeys="$remoteDirectory/public-keys"
-	mkdir "$publicKeys"
-	declare repo="$remoteDirectory/repo"
-	mkdir "$repo"
-	declare gpgDir="$publicKeys/gpg"
-	mkdir "$gpgDir"
-	chmod 700 "$gpgDir"
+		mkdir "$remoteDirectory" || (printf >&2 "\033[1;31mERROR\033[0m: failed to create remote directory %s\n" "$remoteDirectory" && exit 1)
+		echo "--directory \"$pullDirectory\"" >"$remoteDirectory/pull.args"
 
-	declare current
-	current=$(pwd)
-	cd "$repo"
+		mkdir "$publicKeys"
+		mkdir "$repo"
+		mkdir "$gpgDir"
+		chmod 700 "$gpgDir"
 
-	# show commands in output
-	set -x
-	git init
-	git remote add "$remote" "$url"
+		cd "$repo"
 
-	cd "$current"
-	# we need to copy the git config away in order that one can commit it
-	# this file will be used to restore the config for those who have not setup the remote on their machine
-	cp "$repo/.git/config" "$remoteDirectory/gitconfig"
+		# show commands in output
+		set -x
+		git init
+		git remote add "$remote" "$url"
 
-	cd "$repo"
-	declare defaultBranch
-	defaultBranch="$(git remote show "$remote" | sed -n '/HEAD branch/s/.*: //p')"
+		cd "$currentDir"
+		# we need to copy the git config away in order that one can commit it
+		# this file will be used to restore the config for those who have not setup the remote on their machine
+		cp "$repo/.git/config" "$remoteDirectory/gitconfig"
 
-	git fetch --depth 1 "$remote" "$defaultBranch"
+		cd "$repo"
+		defaultBranch="$(git remote show "$remote" | sed -n '/HEAD branch/s/.*: //p')"
 
-	# don't show commands in output anymore
-	{ set +x; } 2>/dev/null
+		git fetch --depth 1 "$remote" "$defaultBranch"
 
-	set +e
-	git checkout "$remote/$defaultBranch" -- '.gget'
-	declare checkoutResult=$?
-	set -e
-	if ! ((checkoutResult == 0)); then
-		if [ "$unsecure" == true ]; then
-			printf "\033[1;33mWARNING\033[0m: no GPG key found, ignoring it because --unsecure true was specified\n"
-			echo "--unsecure true" >>"$workingDirectory/pull.args"
-			exit 0
-		else
-			printf >&2 "\033[1;31mERROR\033[0m: remote \033[0;36m%s\033[0m has no directory \033[0;36m.gget\033[0m defined in branch \033[0;36m%s\033[0m, unable to fetch the GPG key(s)\n" "$remote" "$defaultBranch"
+		# don't show commands in output anymore
+		{ set +x; } 2>/dev/null
+
+		set +e
+		git checkout "$remote/$defaultBranch" -- '.gget'
+		set -e
+		local -ri checkoutResult=$?
+
+		if ! ((checkoutResult == 0)); then
+			if [ "$unsecure" == true ]; then
+				printf "\033[1;33mWARNING\033[0m: no GPG key found, ignoring it because %s true was specified\n" "$UNSECURE_PATTERN"
+				echo "$UNSECURE_PATTERN true" >>"$workingDirectory/pull.args"
+				exit 0
+			else
+				printf >&2 "\033[1;31mERROR\033[0m: remote \033[0;36m%s\033[0m has no directory \033[0;36m.gget\033[0m defined in branch \033[0;36m%s\033[0m, unable to fetch the GPG key(s)\n" "$remote" "$defaultBranch"
+				exit 1
+			fi
+		fi
+
+		function findAsc() {
+			find "$repo/.gget" -maxdepth 1 -type f -name "*.asc" "$@"
+		}
+		if (($(findAsc | wc -l) == 0)); then
+			printf >&2 "\033[1;31mERROR\033[0m: remote \033[0;36m%s\033[0m has a directory \033[0;36m.gget\033[0m but no GPG key ending in *.asc defined in it\n" "$remote"
 			exit 1
 		fi
-	fi
 
-	function findAsc() {
-		find "$repo/.gget" -maxdepth 1 -type f -name "*.asc" "$@"
+		local -i numberOfImportedKeys=0
+
+		local tmpFile
+		tmpFile=$(mktemp /tmp/gget.XXXXXXXXX)
+		exec 3>"$tmpFile"
+		exec 4<"$tmpFile"
+		rm "$tmpFile"
+
+		findAsc -print0 >&3
+
+		echo ""
+		while read -u 4 -r -d $'\0' file; do
+			if importKey "$gpgDir" "$file" --confirm=true; then
+				mv "$file" "$publicKeys/"
+				((numberOfImportedKeys += 1))
+			else
+				echo "deleting key $file"
+				rm "$file"
+			fi
+		done
+		exec 3>&-
+		exec 4<&-
+		rm -r "$repo/.gget"
+
+		if ((numberOfImportedKeys == 0)); then
+			if [ "$unsecure" == true ]; then
+				printf "\033[1;33mWARNING\033[0m: no GPG keys imported, ignoring it because %s true was specified\n" "$UNSECURE_PATTERN"
+				exit 0
+			else
+				printf >&2 "\033[1;31mERROR\033[0m: no GPG keys imported, you won't be able to pull files from the remote \033[0;36m%s\033[0m without using %s true\n" "$remote" "$UNSECURE_PATTERN"
+				exit 1
+			fi
+		fi
+
+		gpg --homedir "$gpgDir" --list-sig
+		printf "\033[1;32mSUCCESS\033[0m: remote \033[0;36m%s\033[0m was set up successfully; imported %s GPG key(s) for verification.\nYou are ready to pull files via:\ngget pull -r %s -t <VERSION> -p <PATH>\n" "$remote" "$numberOfImportedKeys" "$remote"
 	}
-	if (($(findAsc | wc -l) == 0)); then
-		printf >&2 "\033[1;31mERROR\033[0m: remote \033[0;36m%s\033[0m has a directory \033[0;36m.gget\033[0m but no GPG key ending in *.asc defined in it\n" "$remote"
-		exit 1
-	fi
 
-	echo ""
-	declare numberOfImportedKeys=0
+	function list() {
+		local workingDirectory
+		# shellcheck disable=SC2034
+		local -ra params=(
+			workingDirectory "$WORKING_DIR_PATTERN" '(optional) define a path which gget shall use as working directory -- default: .gget'
+		)
+		local -r examples=$(
+			cat <<-EOM
+				# lists all defined remotes in .gget
+				gget remote list
 
-	declare tmpFile
-	tmpFile=$(mktemp /tmp/gget.XXXXXXXXX)
-	exec 3>"$tmpFile"
-	exec 4<"$tmpFile"
-	rm "$tmpFile"
+				# uses a custom working directory
+				gget remote list -w .github/.gget
+			EOM
+		)
 
-	findAsc -print0 >&3
+		parseArguments params "$examples" "$@"
+		if ! [ -v workingDirectory ]; then workingDirectory="$DEFAULT_WORKING_DIR"; fi
+		checkAllArgumentsSet params "$examples"
 
-	while read -u 4 -r -d $'\0' file; do
-		if importKey "$gpgDir" "$file" --confirm=true; then
-			mv "$file" "$publicKeys/"
-			((numberOfImportedKeys += 1))
-		else
-			echo "deleting key $file"
-			rm "$file"
+		if ! [ -d "$workingDirectory" ]; then
+			printf >&2 "\033[1;31mERROR\033[0m: working directory %s does not exist\n" "$workingDirectory"
+			echo >&2 "Check for typos and/or use $WORKING_DIR_PATTERN to specify another"
+			exit 9
 		fi
-	done
-	exec 3>&-
-	exec 4<&-
-	rm -r "$repo/.gget"
 
-	if ((numberOfImportedKeys == 0)); then
-		if [ "$unsecure" == true ]; then
-			printf "\033[1;33mWARNING\033[0m: no GPG keys imported, ignoring it because --unsecure true was specified\n"
-			exit 0
+		declare remotesDirectory
+		source "$scriptDir/directories.source.sh"
+
+		cd "$remotesDirectory"
+		local output
+		output="$(find . -maxdepth 1 -type d -not -path "." | cut -c 3-)"
+		if [ "$output" == "" ]; then
+			printf "\033[1;33mNo remote define yet.\033[0m\n"
+			echo "To add one, use: gget remote add ..."
+			echo "Following the corresponding documentation of the parameters:"
+			add "--help"
 		else
-			printf >&2 "\033[1;31mERROR\033[0m: no GPG keys imported, you won't be able to pull files from the remote \033[0;36m%s\033[0m without using --unsecure true\n" "$remote"
-			exit 1
+			echo "$output"
 		fi
+	}
+
+	function remove() {
+		local workingDirectory
+		# shellcheck disable=SC2034
+		local -ra params=(
+			remote '-r|--remote' 'define the name of the remote which shall be removed'
+			workingDirectory "$WORKING_DIR_PATTERN" '(optional) define a path which gget shall use as working directory -- default: .gget'
+		)
+		local -r examples=$(
+			cat <<-EOM
+				# removes the remote tegonal-scripts
+				gget remote remove -r tegonal-scripts
+
+				# uses a custom working directory
+				gget remote remove -r tegonal-scripts -w .github/.gget
+			EOM
+		)
+
+		parseArguments params "$examples" "$@"
+		if ! [ -v workingDirectory ]; then workingDirectory="$DEFAULT_WORKING_DIR"; fi
+		checkAllArgumentsSet params "$examples"
+
+		declare remoteDirectory
+		source "$scriptDir/directories.source.sh"
+
+		if [ -f "$remoteDirectory" ]; then
+			printf >&2 "\033[1;31mERROR\033[0m: cannot delete remote \033[0;36m%s\033[0m, looks like it is broken there is a file at this location: %s\n" "$remote" "$remoteDirectory"
+			exit 9
+		elif ! [ -d "$remoteDirectory" ]; then
+			printf >&2 "\033[1;31mERROR\033[0m: remote \033[0;36m%s\033[0m does not exist, check for typos.\nFollowing the remotes which exist:\n" "$remote"
+			list -w "$workingDirectory"
+			exit 9
+		fi
+
+		# because files in .git will be write-protected and we don't want sudo for this command
+		chmod -R 777 "$remoteDirectory"
+		rm -r "$remoteDirectory"
+		printf "\033[1;32mSUCCESS\033[0m: removed remote \033[0;36m%s\033[0m\n" "$remote"
+	}
+
+	if [[ $# -lt 1 ]]; then
+		printf >&2 "\033[1;31mERROR\033[0m: At least one parameter needs to be passed\nGiven \033[0;36m%s\033[0m in \033[0;36m%s\033[0m\nFollowing a description of the parameters:\n" "$#" "${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
+		echo >&2 '1. command     one of: add, remove, list'
+		echo >&2 '2... args...   command specific arguments'
+		exit 9
 	fi
 
-	gpg --homedir "$gpgDir" --list-sig
-	printf "\033[1;32mSUCCESS\033[0m: remote \033[0;36m%s\033[0m was set up successfully; imported %s GPG key(s) for verification.\nYou are ready to pull files via:\ngget pull -r %s -t <VERSION> -p <PATH>\n" "$remote" "$numberOfImportedKeys" "$remote"
-}
-
-function remove() {
-	declare workingDirectory
-	# shellcheck disable=SC2034
-	local params=(
-		remote '-r|--remote' 'define the name of the remote which shall be removed'
-		workingDirectory "$WORKING_DIR_PATTERN" '(optional) define a path which gget shall use as working directory -- default: .gget'
-	)
-	declare examples
-	examples=$(
+	declare command=$1
+	shift
+	if [[ "$command" =~ ^(add|remove|list)$ ]]; then
+		"$command" "$@"
+	elif [[ "$command" == "--help" ]]; then
 		cat <<-EOM
-			# removes the remote tegonal-scripts
-			gget remote remove -r tegonal-scripts
-
-			# uses a custom working directory
-			gget remote remove -r tegonal-scripts -w .github/.gget
+			Use one of the following commands:
+			add      add a remote
+			remove   remove a remote
+			list     list all existing remotes
 		EOM
-	)
-
-	parseArguments params "$examples" "$@"
-	if ! [ -v workingDirectory ]; then workingDirectory="$DEFAULT_WORKING_DIR"; fi
-	checkAllArgumentsSet params "$examples"
-
-	declare remoteDirectory="$workingDirectory/$remote"
-
-	if [ -f "$remoteDirectory" ]; then
-		printf >&2 "\033[1;31mERROR\033[0m: cannot delete remote \033[0;36m%s\033[0m, looks like it is broken there is a file at this location: %s\n" "$remote" "$remoteDirectory"
-		exit 9
-	elif ! [ -d "$remoteDirectory" ]; then
-		printf >&2 "\033[1;31mERROR\033[0m: remote \033[0;36m%s\033[0m does not exist, check for typos\n" "$remote"
-		exit 9
-	fi
-
-	# because files in .git will be write-protected and we don't want sudo for this command
-	chmod -R 777 "${workingDirectory}/$remote"
-	rm -r "${workingDirectory:?}/$remote"
-	printf "Removed remote \033[0;36m%s\033[0m" "$remote"
-}
-
-function list() {
-	declare workingDirectory
-	# shellcheck disable=SC2034
-	local params=(
-		workingDirectory "$WORKING_DIR_PATTERN" '(optional) define a path which gget shall use as working directory -- default: .gget'
-	)
-	declare examples
-	examples=$(
-		cat <<-EOM
-			# lists all defined remotes in .gget
-			gget remote list
-
-			# uses a custom working directory
-			gget remote list -w .github/.gget
-		EOM
-	)
-
-	parseArguments params "$examples" "$@"
-	if ! [ -v workingDirectory ]; then workingDirectory="$DEFAULT_WORKING_DIR"; fi
-	checkAllArgumentsSet params "$examples"
-
-	if ! [ -d "$workingDirectory" ]; then
-		printf >&2 "\033[1;31mERROR\033[0m: working directory %s does not exist\n" "$workingDirectory"
-		echo >&2 "Check for typos and/or use $WORKING_DIR_PATTERN to specify another"
-		exit 9
-	fi
-
-	cd "$workingDirectory"
-	local output
-	output="$(find . -maxdepth 1 -type d -not -path "." | cut -c 3-)"
-	if [ "$output" == "" ]; then
-		printf "\033[1;33mNo remote define yet.\033[0m\n"
-		echo "To add one, use: gget remote add ..."
-		echo "Following the corresponding documentation of the parameters:"
-		add "--help"
 	else
-		echo "$output"
+		printf >&2 "\033[1;31mERROR\033[0m: unknown command %s, expected one of add, list, remove\n" "$command"
+		exit 9
 	fi
 }
-
-if [[ $# -lt 1 ]]; then
-	printf >&2 "\033[1;31mERROR\033[0m: At least one parameter needs to be passed\nGiven \033[0;36m%s\033[0m in \033[0;36m%s\033[0m\nFollowing a description of the parameters:\n" "$#" "${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
-	echo >&2 '1. command     one of: add, remove, list'
-	echo >&2 '2... args...   command specific arguments'
-	exit 9
-fi
-
-declare command=$1
-shift
-if [[ "$command" =~ ^(add|remove|list)$ ]]; then
-	"$command" "$@"
-elif [[ "$command" == "--help" ]]; then
-	cat <<-EOM
-		Use one of the following commands:
-		add      add a remote
-		remove   remove a remote
-		list     list all existing remotes
-	EOM
-else
-	printf >&2 "\033[1;31mERROR\033[0m: unknown command %s, expected one of add, list, remove\n" "$command"
-	exit 9
-fi
+gget-remote "$@"

--- a/src/shared-patterns.source.sh
+++ b/src/shared-patterns.source.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC2168
+
+local -r REMOTE_PATTERN='-r|--remote'
+local -r WORKING_DIR_PATTERN='-w|--working-directory'
+local -r PULL_DIR_PATTERN='-d|--directory'
+
+# in case you should add alternatives, then you need to modify gget-remote.sh where we write to pull.args
+local -r UNSECURE_PATTERN='--unsecure'
+
+local -r DEFAULT_WORKING_DIR='.gget'


### PR DESCRIPTION
moreover:
- move all code into functions in order to have fewer effects on parent
  scopes (in case the files are sourced)
- use `local -r` where appropriate



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/tegonal/gget/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
