### PR TITLE
re-use same logic to retrieve latestRemoteTag als in gget update

### DIFF
--- a/src/gget-update.sh
+++ b/src/gget-update.sh
@@ -50,10 +50,6 @@ function gget_update() {
 	local startTime endTime elapsed
 	startTime=$(date +%s.%3N)
 
-	local currentDir
-	currentDir=$(pwd) || die "could not determine currentDir"
-	local -r currentDir
-
 	local defaultWorkingDir
 	source "$dir_of_gget/shared-patterns.source.sh" || die "could not source shared-patterns.source.sh"
 
@@ -112,15 +108,11 @@ function gget_update() {
 		local -r remote=$1
 		shift 1 || die "could not shift by 1"
 
-		local repo
-		source "$dir_of_gget/paths.source.sh" || die "could not source paths.source.sh"
 		local tagToPull
 		if [[ -n $tag ]]; then
 			tagToPull="$tag"
 		else
-			cd "$repo"
-			tagToPull=$(latestRemoteTag "$remote")
-			cd "$currentDir"
+			tagToPull=$(latestRemoteTagIncludingChecks "$workingDirAbsolute" "$remote") || die "could not determine latest tag, see above"
 		fi
 
 		function gget_update_rePullInternal_callback() {

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -136,3 +136,34 @@ function initialiseGpgDir() {
 	# so the user could be aware of that something went wrong
 	chmod 700 "$gpgDir" || true
 }
+
+function latestRemoteTagIncludingChecks() {
+	if ! (($# == 2)); then
+		logError "you need to pass two arguments to latestRemoteTagIncludingChecks, given %s" "$#"
+		echo "1: workingDirAbsolute"
+		echo "2: remote"
+		printStackTrace
+		exit 9
+	fi
+	local -r workingDirAbsolute=$1
+	local -r remote=$2
+
+	local repo
+	source "$dir_of_gget/paths.source.sh" || die "could not source paths.source.sh"
+
+	local currentDir
+	currentDir=$(pwd)
+
+	local tagPattern
+	source "$dir_of_gget/shared-patterns.source.sh" || die "could not source shared-patterns.source.sh"
+
+	logInfo >&2 "no tag provided via argument %s, will determine latest and use it instead" "$tagPattern"
+	cd "$repo" || die "could not cd to the repo to determine the latest tag: %s" "$repo"
+	#		git fetch "$remote" 'refs/tags/*:refs/tags/*' || die "could not fetch the tags of remote %s and thus cannot determine latest tag"
+	latestRemoteTag "$remote" || die "could not determine latest tag of remote \033[0;36m%s\033[0m and none set via argument %s" "$remote" "$tagPattern"
+	if [[ -z $tag ]]; then
+		die "looks like remote \033[0;36m%s\033[0m does not have a tag yet, cannot pull files from it." "$remote"
+	fi
+	cd "$currentDir"
+	logInfo >&2 "latest is \033[0;36m%s\033[0m" "$tag"
+}


### PR DESCRIPTION
check about empty tag is now performed in latestRemoteTag
(due to update to tegonal-scripts v0.15.1)



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gget/blob/v0.5.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
