### PR TITLE
cd back to current dir after successful pull

### DIFF
--- a/src/gget-pull.sh
+++ b/src/gget-pull.sh
@@ -264,6 +264,8 @@ function gget_pull() {
 	}
 	gget_pull_pullSignatureOfSingleFetchedFile
 
+	cd "$currentDir"
+
 	local pullHookBefore="gget_pull_noop"
 	local pullHookAfter="gget_pull_noop"
 	if [[ -f $pullHookFile ]]; then
@@ -366,6 +368,7 @@ function gget_pull() {
 	done < <(find "$path" -type f -not -name "*.$sigExtension" -print0 ||
 		# `while read` will fail because there is no \0
 		true)
+
 
 	endTime=$(date +%s.%3N)
 	elapsed=$(bc <<<"scale=3; $endTime - $startTime")


### PR DESCRIPTION
not only during exit as we might call the function gget_pull (as we do in gget update)



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gget/blob/v0.7.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
